### PR TITLE
fixed DEPRECATED warnings for current provider region

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -1,7 +1,5 @@
 // Data sources
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}
 
 // Create a security group policy and setup rules for Threat Manager appliance
 resource "aws_security_group" "tmc_sg" {


### PR DESCRIPTION
```
Warning: data.aws_region.current: "current": [DEPRECATED] Defaults to current provider region if no other filtering is enabled 
```