### PR TITLE
bump code to support 0.12 and up

### DIFF
--- a/aws/threat-manager/output.tf
+++ b/aws/threat-manager/output.tf
@@ -1,12 +1,12 @@
 // Outputs
 output "tmc_public_ip" {
-	value = "${aws_eip.tmc.*.public_ip}"
+  value = "${aws_eip.tmc.*.public_ip}"
 }
 
 output "tmc_private_ip" {
-	value = "${aws_instance.tmc.*.private_ip}"
+  value = "${aws_instance.tmc.*.private_ip}"
 }
 
 output "tmc_sg_id" {
-	value = "${aws_security_group.tmc_sg.id}"
+  value = "${aws_security_group.tmc_sg.id}"
 }

--- a/aws/threat-manager/vars.tf
+++ b/aws/threat-manager/vars.tf
@@ -1,9 +1,9 @@
 # Specify the provider and access details below
 
 provider "aws" {
-  region     = "${var.aws_region}"
-  access_key = "${var.aws_access_key_id}"
-  secret_key = "${var.aws_secret_access_key}"
+  region     = var.aws_region
+  access_key = var.aws_access_key_id
+  secret_key = var.aws_secret_access_key
   version    = "~> 1.6"
 }
 
@@ -52,11 +52,13 @@ variable "monitoring_cidr" {
 
 variable "create_eip" {
   description = "Set value to 1(true) if you want to deploy it on public subnet, otherwise set to 0(false)"
+  type        = number
 }
 
 variable "alertlogic_enabled" {
   description = "Set value to 1(true) if you want to deploy alertlogic tmc instance, otherwise set to 0(false)"
-  default     = "1"
+  type        = number
+  default     = 1
 }
 
 # Latest AMI as per Mar 2018, contact AlertLogic (support@alertlogic.com) if you want to see the latest AMI per region


### PR DESCRIPTION
While deploying an appliance using Terraform v0.12.29 had to do some fixes to accommodate for new syntax.  